### PR TITLE
Gradle tweaks since ScalaLib is still on its own

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,21 +18,20 @@ import org.reflections.util.ConfigurationBuilder;
 // Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(
 buildscript {
     repositories {
+        // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
+        jcenter()
         mavenCentral()
-        maven {
-            url 'http://dl.bintray.com/jfrog/jfrog-jars'
-        }
     }
 
     dependencies {
         // Artifactory plugin
-        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '2.2.3')
+        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.0.0')
 
         // Git plugin for Gradle
         classpath 'org.ajoberstar:gradle-git:0.6.3'
 
         // Needed for caching reflected data during builds
-        classpath 'org.reflections:reflections:0.9.9'
+        classpath 'org.reflections:reflections:0.9.10'
         classpath 'dom4j:dom4j:1.6.1'
     }
 }
@@ -176,7 +175,6 @@ dependencies {
         }
     }
 }
-
 
 // Change the output dir of each module
 sourceSets {

--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
 	"id"                : "ScalaLib",
-	"version"           : "1.0.0",
+	"version"           : "1.0.1-SNAPSHOT",
 	"author"            : "skaldarnar",
 	"displayName"       : "Scala Runtime Library Module",
 	"description"       : "Library module that supplies the Scala runtime library. See www.scala-lang.org for more information.",


### PR DESCRIPTION
Made these minor changes in engine + all regular modules, sending them your way so we don't forget :-)

Want to transfer the repo to the Terasology org so we can just maintain it there? I'd like to work on giving it a more permanent build setup, in the meantime I've just had Jenkins build my fork for now.
